### PR TITLE
input group support

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -1023,11 +1023,6 @@ th {
     padding-right: 0;
 }
 
-.input-group .input-group-addon {
-    padding-top: 5px;
-    padding-bottom: 5px;
-}
-
 /***** Form Controls ****************************/
 
 .form-control {
@@ -1042,6 +1037,11 @@ th {
     margin-top: initial;
 }
 
+
+.input-group .input-group-addon {
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
 
 
 .required:before {

--- a/css/app.css
+++ b/css/app.css
@@ -1022,6 +1022,12 @@ th {
     padding-left: 0;
     padding-right: 0;
 }
+
+.input-group .input-group-addon {
+    padding-top: 5px;
+    padding-bottom: 5px;
+}
+
 /***** Form Controls ****************************/
 
 .form-control {

--- a/css/app.css
+++ b/css/app.css
@@ -1028,6 +1028,16 @@ th {
     margin-top: 8px;
 }
 
+.input-group {
+    padding-top: 8px;
+}
+
+.input-group .form-control {
+    margin-top: initial;
+}
+
+
+
 .required:before {
     color: red;
     content: '*';


### PR DESCRIPTION
1) Removed the margin from `.form-control` that are in `.input-group` and applied an the 8px padding to `.input-group` itself.

2) Reduced to vertical padding on an `.input-group-addon` by 2px  to account for the shorter text boxes.

3) Committed with the style in the wrong location. Corrected this.
